### PR TITLE
Add web-based reaction game

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,6 @@ Public landing page: <https://pawelwielga.github.io/czarek/>
 - **Kolonia Nad LiPau** (`kolonia.html`)
 - **Kropki.io** (`kropki.html`)
 - **Evolution Game** (`evolution-game.html`)
+- **Reaction Game** (`reaction-game.html`)
+
+- **Reaction Game (Verilog)** (`hdl/reaction_game`)

--- a/hdl/reaction_game/README.md
+++ b/hdl/reaction_game/README.md
@@ -1,0 +1,19 @@
+# Reaction Game (Verilog)
+
+This folder contains a simple HDL project implementing a reaction game.
+It was designed for FPGA development boards or logic simulators and uses
+three indicator LEDs, a single push button and four LEDs to display the
+measured reaction time.
+
+## Features
+* One of three LEDs lights up after a random delay.
+* Player must press the button as quickly as possible once the LED lights.
+* Reaction time is measured in 10&nbsp;ms units and shown on four LEDs as a
+  binary number (0&ndash;15).
+* Pressing the button before the LED lights results in an error – all LEDs
+  flash for a short time.
+* A `reset` input restarts the game.
+
+The main module is [`reaction_game.v`](reaction_game.v). The design is
+self-contained and can be simulated with popular Verilog tools such as
+`iverilog` or synthesized for an FPGA.

--- a/hdl/reaction_game/reaction_game.v
+++ b/hdl/reaction_game/reaction_game.v
@@ -1,0 +1,139 @@
+// Simple reaction game for FPGA or simulator
+// Implements a reaction timer with 3 indicator LEDs and 4 time LEDs.
+// One of three LEDs lights up randomly. The player must press the button
+// as fast as possible when the LED lights. Reaction time is shown in
+// binary on four LEDs. Early button press causes an error flash.
+
+module reaction_game #(
+    parameter CLK_FREQ = 50_000_000   // input clock frequency in Hz
+) (
+    input  wire clk,     // system clock
+    input  wire reset,   // active high synchronous reset
+    input  wire button,  // player button
+    output reg  [2:0] led_select, // one of three LEDs
+    output reg  [3:0] time_leds   // reaction time display
+);
+
+    // generate 10 ms tick for timers
+    localparam integer TICK_CYCLES = CLK_FREQ / 100; // 10ms
+    reg [31:0] tick_cnt = 0;
+    reg tick = 0;
+    always @(posedge clk) begin
+        if (reset) begin
+            tick_cnt <= 0;
+            tick <= 0;
+        end else if (tick_cnt == TICK_CYCLES-1) begin
+            tick_cnt <= 0;
+            tick <= 1;
+        end else begin
+            tick_cnt <= tick_cnt + 1;
+            tick <= 0;
+        end
+    end
+
+    // simple 8-bit LFSR for pseudo random numbers
+    reg [7:0] lfsr = 8'h1;
+    wire lfsr_fb = lfsr[7] ^ lfsr[5] ^ lfsr[4] ^ lfsr[3];
+    always @(posedge clk) begin
+        if (reset)
+            lfsr <= 8'h1;
+        else if (tick)
+            lfsr <= {lfsr[6:0], lfsr_fb};
+    end
+
+    // button edge detection (debounced using tick)
+    reg [1:0] btn_sync = 0;
+    always @(posedge clk) btn_sync <= {btn_sync[0], button};
+    reg btn_prev = 0;
+    wire btn_edge;
+    always @(posedge clk) begin
+        if (reset)
+            btn_prev <= 0;
+        else if (tick)
+            btn_prev <= btn_sync[1];
+    end
+    assign btn_edge = btn_sync[1] & ~btn_prev;
+
+    // FSM states
+    localparam S_IDLE  = 3'd0,
+               S_DELAY = 3'd1,
+               S_WAIT  = 3'd2,
+               S_SHOW  = 3'd3,
+               S_ERR   = 3'd4;
+
+    reg [2:0] state = S_IDLE;
+    reg [7:0] delay_cnt = 0;    // random delay before LED lights
+    reg [3:0] react_cnt = 0;    // reaction time counter
+    reg [7:0] show_cnt  = 0;    // show/error duration
+    reg flash = 0;              // flashing flag for error
+
+    always @(posedge clk) begin
+        if (reset) begin
+            state <= S_IDLE;
+            led_select <= 3'b000;
+            time_leds <= 4'b0000;
+            delay_cnt <= 0;
+            react_cnt <= 0;
+            show_cnt <= 0;
+            flash <= 0;
+        end else if (tick) begin
+            case (state)
+                S_IDLE: begin
+                    led_select <= 3'b000;
+                    time_leds <= 4'b0000;
+                    delay_cnt <= lfsr;          // 0..255 * 10ms
+                    if (btn_edge) begin
+                        state <= S_ERR;         // early press
+                        show_cnt <= 50;         // ~0.5s
+                    end else begin
+                        state <= S_DELAY;
+                    end
+                end
+                S_DELAY: begin
+                    if (btn_edge) begin
+                        state <= S_ERR;         // early press
+                        show_cnt <= 50;
+                    end else if (delay_cnt == 0) begin
+                        case (lfsr[1:0])
+                            2'b00: led_select <= 3'b001;
+                            2'b01: led_select <= 3'b010;
+                            default: led_select <= 3'b100;
+                        endcase
+                        react_cnt <= 0;
+                        state <= S_WAIT;
+                    end else begin
+                        delay_cnt <= delay_cnt - 1;
+                    end
+                end
+                S_WAIT: begin
+                    if (btn_edge) begin
+                        time_leds <= react_cnt;
+                        show_cnt <= 100;        // show for 1s
+                        state <= S_SHOW;
+                    end else begin
+                        if (react_cnt != 4'hF)
+                            react_cnt <= react_cnt + 1;
+                    end
+                end
+                S_SHOW: begin
+                    led_select <= 3'b000;
+                    if (show_cnt == 0)
+                        state <= S_IDLE;
+                    else
+                        show_cnt <= show_cnt - 1;
+                end
+                S_ERR: begin
+                    flash <= ~flash;
+                    led_select <= flash ? 3'b111 : 3'b000;
+                    time_leds <= flash ? 4'b1111 : 4'b0000;
+                    if (show_cnt == 0)
+                        state <= S_IDLE;
+                    else
+                        show_cnt <= show_cnt - 1;
+                end
+            endcase
+        end
+    end
+
+endmodule
+

--- a/index.html
+++ b/index.html
@@ -79,6 +79,10 @@
                 <span class="text-4xl mb-2">🦠</span>
                 <span>Evolution Game</span>
             </a>
+            <a href="reaction-game.html" class="flex flex-col items-center p-4 bg-white rounded shadow hover:bg-green-50">
+                <span class="text-4xl mb-2">⚡</span>
+                <span>Reaction Game</span>
+            </a>
         </div>
         <form onsubmit="alert('Dzięki za wiadomość!'); return false;" class="space-y-2">
             <input type="text" placeholder="Twoje imię" required class="border p-2 w-full">

--- a/reaction-game.html
+++ b/reaction-game.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Prosta gra na refleks">
+    <title>Reaction Game</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+        :root { --main-color:#065f46; --bg-color:#f0fdf4; }
+        html { scroll-behavior:smooth; }
+        body{ background-color:var(--bg-color); color:var(--main-color); }
+        body.dark-mode{ background-color:#111; color:#fff; }
+        nav ul{ display:none; }
+        nav.open ul{ display:block; }
+        @media(min-width:640px){ nav ul{display:flex;} .menu-button{display:none;} }
+        button:hover{ transform:scale(1.05); transition:transform 0.2s; }
+        #leds span,#timeleds span{
+            display:inline-block; width:24px; height:24px; margin:4px;
+            border-radius:50%; background:#9ca3af;
+        }
+        .on{ background:#dc2626; }
+    </style>
+</head>
+<body class="flex flex-col items-center">
+<header class="bg-green-700 text-white w-full">
+    <nav class="container mx-auto flex items-center justify-between p-4">
+        <a href="index.html" class="text-2xl font-bold">Gry Czarka</a>
+        <button class="menu-button" aria-label="Otwórz menu">☰</button>
+        <button id="darkToggle">Przełącz tryb</button>
+        <button onclick="location.href='index.html'" class="ml-4 px-4 py-2 bg-white text-green-700 rounded">Strona główna</button>
+    </nav>
+</header>
+<main class="container mx-auto p-8 space-y-4 flex flex-col items-center">
+    <h1 class="text-3xl font-bold">Reaction Game</h1>
+    <img src="https://via.placeholder.com/150" loading="lazy" alt="Rysunek Czarka" class="mx-auto">
+    <div id="leds" class="flex"></div>
+    <button id="action" class="px-4 py-2 bg-green-700 text-white rounded">Naciśnij</button>
+    <div id="info" class="h-6"></div>
+    <div id="timeleds" class="flex"></div>
+    <button id="reset" class="px-4 py-2 bg-green-700 text-white rounded">Resetuj</button>
+</main>
+<footer class="mt-8 text-center text-sm text-green-600">
+    <p>&copy; 2024 Gry Czarka</p>
+</footer>
+<script>
+const ledsDiv = document.getElementById('leds');
+const timeDiv = document.getElementById('timeleds');
+for(let i=0;i<3;i++){ const s=document.createElement('span'); ledsDiv.appendChild(s); }
+for(let i=0;i<4;i++){ const s=document.createElement('span'); timeDiv.appendChild(s); }
+const leds=[...ledsDiv.children];
+const timeLeds=[...timeDiv.children];
+const info=document.getElementById('info');
+let state='idle', startTime=0, delayId, flashInt, flashes=0;
+function setLeds(idx){ leds.forEach((l,i)=>l.classList.toggle('on',i===idx)); }
+function clearTime(){ timeLeds.forEach(l=>l.classList.remove('on')); }
+function showTime(ms){ const val=Math.min(15,Math.floor(ms/100)); timeLeds.forEach((l,i)=>l.classList.toggle('on', val>>i & 1)); info.textContent=`Czas reakcji: ${ms.toFixed(0)} ms`; }
+function startGame(){ clearTimeout(delayId); clearInterval(flashInt); flashes=0; state='wait'; setLeds(-1); clearTime(); info.textContent='Czekaj...'; delayId=setTimeout(()=>{ state='go'; setLeds(Math.floor(Math.random()*3)); startTime=performance.now(); info.textContent='Naciśnij teraz!'; },2000+Math.random()*2000); }
+function flashError(){ flashInt=setInterval(()=>{ leds.forEach(l=>l.classList.toggle('on')); timeLeds.forEach(l=>l.classList.toggle('on')); if(++flashes>6){ clearInterval(flashInt); startGame(); } },200); info.textContent='Za wcześnie!'; }
+function press(){ if(state==='go'){ const t=performance.now()-startTime; setLeds(-1); showTime(t); state='done'; } else if(state==='wait'){ state='error'; clearTimeout(delayId); flashError(); } }
+document.getElementById('action').onclick=press; document.getElementById('reset').onclick=startGame; window.onload=startGame;
+</script>
+<script>
+    document.querySelector('.menu-button').addEventListener('click', () => {
+        document.querySelector('nav').classList.toggle('open');
+    });
+    document.querySelector('#darkToggle').addEventListener('click', () => {
+        document.body.classList.toggle('dark-mode');
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add simple reaction game in HTML/JS for browsers
- link the new game from the index page and main README

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_6853fbf0c0bc8328a532f6efa8df69e9